### PR TITLE
Correção da netlist de componentes e adição de testes

### DIFF
--- a/simulador/componentes.py
+++ b/simulador/componentes.py
@@ -76,9 +76,9 @@ class Indutor(Componente):
 
     def __str__(self):
         if self.ic == 0.0:
-            return 'I' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor)
+            return 'L' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor)
         else:
-            return 'I' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor) + ' IC=' + str(self.ic)
+            return 'L' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor) + ' IC=' + str(self.ic)
     
     def estampaDC(self, Gn, I):
         pass

--- a/simulador/componentes.py
+++ b/simulador/componentes.py
@@ -122,7 +122,7 @@ class FonteTensaoTensao(Componente):
         self.valor = valor
     
     def __str__(self):
-        return 'F' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor)
+        return 'E' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor)
     
     def estampaDC(self, Gn, I):
         pass
@@ -142,7 +142,7 @@ class FonteCorrenteCorrente(Componente):
         self.valor = valor
     
     def __str__(self):
-        return 'G' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor)
+        return 'F' + self.name + ' ' + ' '.join(str(no) for no in self.nos) + ' ' + str(self.valor)
     
     def estampaDC(self, Gn, I):
         pass

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,6 +1,12 @@
 import pytest
 import simulador
 
+def check_netlist(filename):
+    ref = open(filename)
+    test = open(filename + '.test')
+    for line1, line2 in zip(ref, test):
+        assert line1.strip() == line2.strip()
+
 def test_chua():
     c = simulador.Circuito('.TRAN', 1000, 0.1, 'BE', 1)
     c.append(simulador.Resistor('1004', ['1', '2'], 1.9))
@@ -8,6 +14,7 @@ def test_chua():
     c.append(simulador.Capacitor('2000', ['2', '0'], 0.31, ic=1))
     c.append(simulador.Capacitor('2001', ['1', '0'], 1, ic=1))
     c.export('tests/chua.net.test')
+    check_netlist('tests/chua.net')
 
 def test_dc_source():
     c = simulador.Circuito('.TRAN', 0.1, 1e-05, 'BE', 1)
@@ -16,6 +23,7 @@ def test_dc_source():
     c.append(simulador.Resistor('1005', ['2', '0'], 1000.0))
     c.append(simulador.Capacitor('2005', ['2', '0'], 4.9999999999999996e-05))
     c.export('tests/dc_source.net.test')
+    check_netlist('tests/dc_source.net')
     
 def test_lc():
     c = simulador.Circuito('.TRAN', 0.003, 3e-07, 'BE', 1)
@@ -29,6 +37,7 @@ def test_lc():
     c.append(simulador.FonteTensaoTensao('7001', ['5', '4', '2', '0'], 1))
     c.append(simulador.FonteTensaoTensao('7002', ['6', '5', '1', '0'], 1))
     c.export('tests/lc.net.test')
+    check_netlist('tests/lc.net')
 
 def test_mosfet_curve():
     pass
@@ -46,6 +55,7 @@ def test_oscilator():
     c.append(simulador.Diodo('1203', ['5', '4']))
     c.append(simulador.Diodo('1204', ['4', '5']))
     c.export('tests/oscilator.net.test')
+    check_netlist('tests/oscilator.net')
 
 def test_pulse():
     c = simulador.Circuito('.TRAN', 0.01, 1e-05, 'BE', 1)
@@ -53,6 +63,7 @@ def test_pulse():
     c.append(simulador.Resistor('1002', ['1', '2'], 1000.0))
     c.append(simulador.Resistor('1003', ['2', '0'], 1000.0))
     c.export('tests/pulse.net.test')
+    check_netlist('tests/pulse.net')
     
 def test_sinusoidal():
     c = simulador.Circuito('.TRAN', 0.005, 1e-05, 'BE', 1)
@@ -60,3 +71,4 @@ def test_sinusoidal():
     c.append(simulador.Resistor('1000', ['1', '2'], 1000.0))
     c.append(simulador.Resistor('1001', ['2', '0'], 1000.0))
     c.export('tests/sinusoidal.net.test')
+    check_netlist('tests/sinusoidal.net')


### PR DESCRIPTION
Corrigidas as representações de netlists dos seguintes componentes:
- Indutor (L<nome> <no1> <no2> <indutancia>)
- Fonte de tensão controlada por tensão (E<nome> <no_tensao_+> <no_tensao_-> <no_controle_+> <no_controle_-> <ganho>)
- Fonte de corrente controlada por corrente (F<nome> <no_tensao_+> <no_tensao_-> <no_controle_+> <no_controle_-> <ganho>)
Além disso, adicionei o teste para verificar a netlist gerada com a netlist de referência. Um teste quebrou porque não sei o que é o componente N, então não tem como testar esse caso.