### PR TITLE
Adicionando loop de simulação inicial

### DIFF
--- a/simulador/__init__.py
+++ b/simulador/__init__.py
@@ -89,7 +89,7 @@ class Circuito():
                 if len(resultado) == 0:
                     previous = [0.0 for i in range(len(self.__nos))]
                 else:
-                    previous = resultado[0]
+                    previous = resultado[-1][1] # resultado[i] = (tempo, [tensoes])
                 while True:
                     '''Parte que testa que nao converge'''
                     matrizGn = np.zeros((len(self.__nos), len(self.__nos)))#, dtype=np.complex64)


### PR DESCRIPTION
Neste PR, adicionei uma primeira versão do loop de simulação. No momento, pude testar que funciona para análise bias (isto é, circuito independente do tempo). Nos próximos PRs devemos consertar e melhorar este loop para funcionar no tempo e com componentes não lineares.