### PR TITLE
Consertando args FonteTensao e FonteCorrente

### DIFF
--- a/simulador/componentes.py
+++ b/simulador/componentes.py
@@ -972,7 +972,7 @@ class FonteCorrente(Componente):
     # @details A fonte injeta uma corrente constante fluindo do nó a para o nó b.
     def __init__(self, name: str, nos: list[str], args: list):
         super().__init__(name, nos)
-        args = [str(arg) for arg in self.args] # forca args como strings
+        args = [str(arg) for arg in args] # forca args como strings
         self.processa_argumentos_fonte(args)
         self.args = args
 
@@ -1021,7 +1021,7 @@ class FonteTensao(Componente):
     # @details A fonte fixa uma diferença de potencial constante entre os nós (Va - Vb = valor).
     def __init__(self, name: str, nos: list[str], args: list):
         super().__init__(name, nos)
-        args = [str(arg) for arg in self.args] # forca args como strings
+        args = [str(arg) for arg in args] # forca args como strings
         self.processa_argumentos_fonte(args)
         self.args = args
 

--- a/simulador/componentes.py
+++ b/simulador/componentes.py
@@ -972,6 +972,7 @@ class FonteCorrente(Componente):
     # @details A fonte injeta uma corrente constante fluindo do nó a para o nó b.
     def __init__(self, name: str, nos: list[str], args: list):
         super().__init__(name, nos)
+        args = [str(arg) for arg in self.args] # forca args como strings
         self.processa_argumentos_fonte(args)
         self.args = args
 
@@ -1020,6 +1021,7 @@ class FonteTensao(Componente):
     # @details A fonte fixa uma diferença de potencial constante entre os nós (Va - Vb = valor).
     def __init__(self, name: str, nos: list[str], args: list):
         super().__init__(name, nos)
+        args = [str(arg) for arg in self.args] # forca args como strings
         self.processa_argumentos_fonte(args)
         self.args = args
 

--- a/simulador/componentes.py
+++ b/simulador/componentes.py
@@ -1017,7 +1017,7 @@ class FonteTensao(Componente):
     ## @brief Construtor da Fonte de tensão
     # @param name Nome único da fonte
     # @param nos Lista com dois nós: [nó_a, nó_b]
-    # @param valor Tensão em Volts
+    # @param args Parâmetros em formato netlist
     # @details A fonte fixa uma diferença de potencial constante entre os nós (Va - Vb = valor).
     def __init__(self, name: str, nos: list[str], args: list):
         super().__init__(name, nos)


### PR DESCRIPTION
Quando a netlist é importada ou quando componentes são instanciados nos testes de `test_code`, utilizamos `args` com todos os argumentos sendo string. Porém, na interface programática, pode fazer sentido fornecer argumentos como `string` ou como `float`. No segundo caso, o export de netlist quebra, pois o Python só aceita concatenar `string`.

Este PR adiciona um casting de todos os argumentos de `args` como `string`, permitindo o uso da interface programática de ambas as formas.